### PR TITLE
Base for request builders and remaining request builders for documents have been developed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "php": ">=7.2",
         "psr/log": "^1.1",
-        "symfony/http-client": "^5.4"
+        "symfony/http-client": "^5.4",
+        "doctrine/annotations": "^1.13"
     },
     "license": "MIT",
     "authors": [

--- a/src/Model/RequestInterface.php
+++ b/src/Model/RequestInterface.php
@@ -10,6 +10,11 @@ interface RequestInterface
     public const API_NAME_SIGN_DOCUMENT_MOBILE_ID = 'apiSignDocumentMobileId';
     public const API_NAME_DOCUMENT_UPLOAD = 'apiDocumentUpload';
     public const API_NAME_DOCUMENT_VALIDATION = 'apiDocumentValidation';
+    public const API_NAME_DOCUMENT_FILE_VALIDATION = 'apiDocumentFileValidation';
+    public const API_NAME_DOCUMENT_SIGNER_INVITE = 'apiDocumentSignerInvite';
+    public const API_NAME_DOCUMENT_STATUS_CHECK = 'apiDocumentStatusCheck';
+    public const API_NAME_DOCUMENT_DOWNLOAD = 'apiDocumentDownload';
+    public const API_NAME_DOCUMENT_REMOVE = 'apiDocumentRemove';
 
     /**
      * @return string

--- a/src/Model/Response.php
+++ b/src/Model/Response.php
@@ -36,4 +36,16 @@ class Response implements ResponseInterface
     {
         return $this->response->toArray(false);
     }
+
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders(false);
+    }
+
+    public function getHeader(string $headerName)
+    {
+        $headers = $this->getHeaders();
+        $headerName = strtolower($headerName);
+        return (isset($headers[$headerName]) && isset($headers[$headerName][0])) ? $headers[$headerName][0] : null;
+    }
 }

--- a/src/RequestBuilder/AbstractRequestBuilder.php
+++ b/src/RequestBuilder/AbstractRequestBuilder.php
@@ -3,6 +3,7 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
+use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 
 abstract class AbstractRequestBuilder implements RequestBuilderInterface
 {
@@ -20,5 +21,22 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
         $this->apiKey = $apiKey;
 
         return $this;
+    }
+
+    /**
+     * @var array
+     */
+    protected $bodyParams = [];
+
+    /**
+     * @throws MissingParameterException
+     */
+    protected function validateParameters(array $requiredParams)
+    {
+        foreach ($requiredParams as $param) {
+            if (!isset($this->bodyParams[$param])) {
+                throw new MissingParameterException("Missing required request parameter '{$param}'");
+            }
+        }
     }
 }

--- a/src/RequestBuilder/Annotations/RequestParameter.php
+++ b/src/RequestBuilder/Annotations/RequestParameter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AppBundle\GatewaySDKPhp\RequestBuilder\Annotations;
+
+/**
+ * @Annotation
+ */
+final class RequestParameter
+{
+    public $name;
+}

--- a/src/RequestBuilder/DocumentDownloadRequestBuilder.php
+++ b/src/RequestBuilder/DocumentDownloadRequestBuilder.php
@@ -3,14 +3,12 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
-
-use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 use AppBundle\GatewaySDKPhp\Model\Request;
 use AppBundle\GatewaySDKPhp\Model\RequestInterface;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
-class DocumentValidationRequestBuilder extends AbstractRequestBuilder
+class DocumentDownloadRequestBuilder extends AbstractRequestBuilder
 {
     use TraitBuildParameters;
 
@@ -30,10 +28,10 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     {
         $this->bodyParams = $this->buildParameters();
         
-        $this->validateParameters(['access_token', 'documentId']);
+        $this->validateParameters(['access_token']);
         
         $request = new Request();
-        $request->setApiName(Request::API_NAME_DOCUMENT_VALIDATION);
+        $request->setApiName(Request::API_NAME_DOCUMENT_DOWNLOAD);
         
         $request->setBodyParameters($this->bodyParams);
 
@@ -52,7 +50,7 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     }
 
     /**
-     * @param string $access
+     * @param string $documentId
      * @return self
      */
     public function withDocumentId(string $documentId): self

--- a/src/RequestBuilder/DocumentFileValidationRequestBuilder.php
+++ b/src/RequestBuilder/DocumentFileValidationRequestBuilder.php
@@ -3,14 +3,13 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
-
-use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 use AppBundle\GatewaySDKPhp\Model\Request;
 use AppBundle\GatewaySDKPhp\Model\RequestInterface;
+use AppBundle\GatewaySDKPhp\RequestBuilder\Partials\FileUpload;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
-class DocumentValidationRequestBuilder extends AbstractRequestBuilder
+class DocumentFileValidationRequestBuilder extends AbstractRequestBuilder
 {
     use TraitBuildParameters;
 
@@ -21,19 +20,19 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     protected $accessToken;
 
     /**
-     * @var string
-     * @RequestParameter(name = "documentId")
+     * @var FileUpload
+     * @RequestParameter(name = "file")
      */
-    protected $documentId;
+    protected $file;
 
     public function createRequest(): RequestInterface
     {
         $this->bodyParams = $this->buildParameters();
         
-        $this->validateParameters(['access_token', 'documentId']);
+        $this->validateParameters(['access_token', 'file']);
         
         $request = new Request();
-        $request->setApiName(Request::API_NAME_DOCUMENT_VALIDATION);
+        $request->setApiName(Request::API_NAME_DOCUMENT_FILE_VALIDATION);
         
         $request->setBodyParameters($this->bodyParams);
 
@@ -52,12 +51,12 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     }
 
     /**
-     * @param string $access
+     * @param FileUpload $file
      * @return self
      */
-    public function withDocumentId(string $documentId): self
+    public function withFile(FileUpload $file): self
     {
-        $this->documentId = $documentId;
+        $this->file = $file;
 
         return $this;
     }

--- a/src/RequestBuilder/DocumentRemoveRequestBuilder.php
+++ b/src/RequestBuilder/DocumentRemoveRequestBuilder.php
@@ -3,14 +3,12 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
-
-use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 use AppBundle\GatewaySDKPhp\Model\Request;
 use AppBundle\GatewaySDKPhp\Model\RequestInterface;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
-class DocumentValidationRequestBuilder extends AbstractRequestBuilder
+class DocumentRemoveRequestBuilder extends AbstractRequestBuilder
 {
     use TraitBuildParameters;
 
@@ -30,10 +28,10 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     {
         $this->bodyParams = $this->buildParameters();
         
-        $this->validateParameters(['access_token', 'documentId']);
+        $this->validateParameters(['access_token']);
         
         $request = new Request();
-        $request->setApiName(Request::API_NAME_DOCUMENT_VALIDATION);
+        $request->setApiName(Request::API_NAME_DOCUMENT_REMOVE);
         
         $request->setBodyParameters($this->bodyParams);
 
@@ -52,7 +50,7 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     }
 
     /**
-     * @param string $access
+     * @param string $documentId
      * @return self
      */
     public function withDocumentId(string $documentId): self

--- a/src/RequestBuilder/DocumentSignerInviteRequestBuilder.php
+++ b/src/RequestBuilder/DocumentSignerInviteRequestBuilder.php
@@ -3,14 +3,13 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
-
-use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 use AppBundle\GatewaySDKPhp\Model\Request;
 use AppBundle\GatewaySDKPhp\Model\RequestInterface;
+use AppBundle\GatewaySDKPhp\RequestBuilder\Partials\Signer;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
-class DocumentValidationRequestBuilder extends AbstractRequestBuilder
+class DocumentSignerInviteRequestBuilder extends AbstractRequestBuilder
 {
     use TraitBuildParameters;
 
@@ -26,14 +25,20 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
      */
     protected $documentId;
 
+    /**
+     * @var Signer
+     * @RequestParameter(name = "signer")
+     */
+    protected $signer;
+
     public function createRequest(): RequestInterface
     {
         $this->bodyParams = $this->buildParameters();
         
-        $this->validateParameters(['access_token', 'documentId']);
+        $this->validateParameters(['access_token']);
         
         $request = new Request();
-        $request->setApiName(Request::API_NAME_DOCUMENT_VALIDATION);
+        $request->setApiName(Request::API_NAME_DOCUMENT_SIGNER_INVITE);
         
         $request->setBodyParameters($this->bodyParams);
 
@@ -52,12 +57,23 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     }
 
     /**
-     * @param string $access
+     * @param string $documentId
      * @return self
      */
     public function withDocumentId(string $documentId): self
     {
         $this->documentId = $documentId;
+
+        return $this;
+    }
+
+    /**
+     * @param Signer $signer
+     * @return self
+     */
+    public function withSigner(Signer $signer): self
+    {
+        $this->signer = $signer;
 
         return $this;
     }

--- a/src/RequestBuilder/DocumentStatusCheckRequestBuilder.php
+++ b/src/RequestBuilder/DocumentStatusCheckRequestBuilder.php
@@ -3,14 +3,12 @@
 
 namespace AppBundle\GatewaySDKPhp\RequestBuilder;
 
-
-use AppBundle\GatewaySDKPhp\Exception\MissingParameterException;
 use AppBundle\GatewaySDKPhp\Model\Request;
 use AppBundle\GatewaySDKPhp\Model\RequestInterface;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
-class DocumentValidationRequestBuilder extends AbstractRequestBuilder
+class DocumentStatusCheckRequestBuilder extends AbstractRequestBuilder
 {
     use TraitBuildParameters;
 
@@ -30,10 +28,10 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     {
         $this->bodyParams = $this->buildParameters();
         
-        $this->validateParameters(['access_token', 'documentId']);
+        $this->validateParameters(['access_token']);
         
         $request = new Request();
-        $request->setApiName(Request::API_NAME_DOCUMENT_VALIDATION);
+        $request->setApiName(Request::API_NAME_DOCUMENT_STATUS_CHECK);
         
         $request->setBodyParameters($this->bodyParams);
 
@@ -52,7 +50,7 @@ class DocumentValidationRequestBuilder extends AbstractRequestBuilder
     }
 
     /**
-     * @param string $access
+     * @param string $documentId
      * @return self
      */
     public function withDocumentId(string $documentId): self

--- a/src/RequestBuilder/DocumentUploadRequestBuilder.php
+++ b/src/RequestBuilder/DocumentUploadRequestBuilder.php
@@ -10,8 +10,7 @@ use AppBundle\GatewaySDKPhp\Model\RequestInterface;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Partials\FileUpload;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Partials\Signer;
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
-use Symfony\Component\Validator\Validation;
-use Symfony\Component\Validator\Constraints AS Assert;
+use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
 class DocumentUploadRequestBuilder extends AbstractRequestBuilder
 {
@@ -19,48 +18,49 @@ class DocumentUploadRequestBuilder extends AbstractRequestBuilder
 
     /**
      * @var string
+     * @RequestParameter(name = "access_token")
      */
-    protected $access_token;
+    protected $accessToken;
 
     /**
      * @var string
+     * @RequestParameter(name = "access")
      */
     protected $access;
 
     /**
      * @var FileUpload
+     * @RequestParameter(name = "file")
      */
     protected $file;
 
     /**
      * @var Signer[]
+     * @RequestParameter(name = "signers")
      */
     protected $signers;
 
     public function createRequest(): RequestInterface
     {
-        $bodyParams = $this->buildParameters();
+        $this->bodyParams = $this->buildParameters();
         
-        // Here, we can pass $bodyParams to $this->validateParameters()
-        // to validate if all the required parameters have been set or not.
-        // We can use any validator that seems suitable
-        $this->validateParameters();
+        $this->validateParameters(['access_token', 'access', 'file', 'signers']);
         
         $request = new Request();
         $request->setApiName(Request::API_NAME_DOCUMENT_UPLOAD);
         
-        $request->setBodyParameters($bodyParams);
+        $request->setBodyParameters($this->bodyParams);
 
         return $request;
     }
 
     /**
-     * @param string $access_token
+     * @param string $accessToken
      * @return self
      */
-    public function withAccessToken(string $access_token): self
+    public function withAccessToken(string $accessToken): self
     {
-        $this->access_token = $access_token;
+        $this->accessToken = $accessToken;
 
         return $this;
     }
@@ -98,17 +98,4 @@ class DocumentUploadRequestBuilder extends AbstractRequestBuilder
         return $this;
     }
 
-    /**
-     * @throws MissingParameterException
-     */
-    private function validateParameters()
-    {
-        $requiredParams = ['access_token', 'access', 'file', 'signers'];
-
-        foreach ($requiredParams as $param) {
-            if (!isset($this->$param)) {
-                throw new MissingParameterException("Missing required request parameter '{$param}'");
-            }
-        }
-    }
 }

--- a/src/RequestBuilder/Partials/FileUpload.php
+++ b/src/RequestBuilder/Partials/FileUpload.php
@@ -3,6 +3,7 @@
 namespace AppBundle\GatewaySDKPhp\RequestBuilder\Partials;
 
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
+use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
 class FileUpload
 {
@@ -12,6 +13,7 @@ class FileUpload
      * Name of the file
      *
      * @var string
+     * @RequestParameter(name = "filename")
      */
     protected $filename;
 
@@ -19,6 +21,7 @@ class FileUpload
      * Base64 encoded content of the file
      *
      * @var string
+     * @RequestParameter(name = "content")
      */
     protected $content;
 
@@ -26,6 +29,7 @@ class FileUpload
      * Callback URL to send uuid after signing
      *
      * @var string
+     * @RequestParameter(name = "callbackUrl")
      */
     protected $callbackUrl;
 

--- a/src/RequestBuilder/Partials/Signer.php
+++ b/src/RequestBuilder/Partials/Signer.php
@@ -3,6 +3,7 @@
 namespace AppBundle\GatewaySDKPhp\RequestBuilder\Partials;
 
 use AppBundle\GatewaySDKPhp\RequestBuilder\Traits\TraitBuildParameters;
+use AppBundle\GatewaySDKPhp\RequestBuilder\Annotations\RequestParameter;
 
 class Signer
 {
@@ -12,6 +13,7 @@ class Signer
      * Signer's name
      *
      * @var string
+     * @RequestParameter(name = "name")
      */
     protected $name;
 
@@ -19,6 +21,7 @@ class Signer
      * Signer's surname
      *
      * @var string
+     * @RequestParameter(name = "surname")
      */
     protected $surname;
 
@@ -26,6 +29,7 @@ class Signer
      * Signer's email
      *
      * @var string
+     * @RequestParameter(name = "email")
      */
     protected $email;
 
@@ -33,6 +37,7 @@ class Signer
      * Document upload success redirection URL
      *
      * @var string
+     * @RequestParameter(name = "successUrl")
      */
     protected $successUrl;
 
@@ -40,6 +45,7 @@ class Signer
      * If TRUE then email with invitation URL will not be sent to signer
      *
      * @var bool
+     * @RequestParameter(name = "noEmail")
      */
     protected $noEmail;
 


### PR DESCRIPTION
1. To get and work with class variables, buildParameters() method now uses ReflectionClass instead of get_class_vars()
2. Annotation system has been added in request builders to help buildParameters() to use parameter name instead of class variables
3. validateParameters() is in AbstractRequestBuilder class and class definition has been updated
4. DocumentValidationRequestBuilder has been created
5. DocumentFileValidationRequestBuilder has been created
6. DocumentSignerInviteRequestBuilder has been created
7. DocumentStatusCheckRequestBuilder has been created
8. DocumentDownloadRequestBuilder has been created
9. DocumentRemoveRequestBuilder has been created