### PR TITLE
Added missing $locale variable to Connector class

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -59,16 +59,23 @@ class Connector implements ConnectorInterface
      * @var LoggerInterface
      */
     private $logger;
+    
+     /**
+     * @var string
+     */
+    private $locale;
 
     /**
      * Connector constructor.
      * @param LoggerInterface $logger
+     * @param string $locale
      */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, string $locale = 'lt')
     {
         $this->apiUrl = "https://www.markid.lt";
         $this->client = HttpClient::create();
         $this->logger = $logger;
+        $this->locale = $locale;
     }
 
     public function postRequest(RequestInterface $request): ResponseInterface


### PR DESCRIPTION
Added missing $locale variable to Connector class constructor, which caused an error `Undefined property: AppBundle\GatewaySDKPhp\Connector::$locale`